### PR TITLE
Add download mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Additionally, you can add the following flags:
 -log-requests # Log requests (this will slow down the server by ~40%)
 -index <file> # The file to serve when the path ends in `/` (default=index.html)
 -spa # Make all 404 pages the index file, useful for SPA apps that use client side routing
+-download # Enable downloading files
 ```
 
 You can just add these to the end of the `docker run` command.

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	fLogRequests   = flag.Bool("log-requests", false, "Log requests to stdout")
 	fSPA           = flag.Bool("spa", false, "Serve index.html for 404 pages (for SPA apps)")
 	fIndex         = flag.String("index", "index.html", "Index file relative from the files path")
+	fDownload      = flag.Bool("download", false, "Enables direct Download for Served Files")
 )
 
 func main() {
@@ -49,6 +50,10 @@ func main() {
 		app.Use(logger.New())
 	}
 
+	if *fDownload {
+		log.Printf("Enabling downloads")
+	}
+
 	if *fCompressLevel > 0 {
 		log.Printf("Enabling compression: %d", *fCompressLevel)
 
@@ -65,7 +70,7 @@ func main() {
 
 	app.Static("/", *fFilePath, fiber.Static{
 		Compress:      true,
-		Download:      false,
+		Download:      *fDownload,
 		CacheDuration: *fCacheDuration,
 		MaxAge:        int((*fCacheDuration).Seconds()),
 		ByteRange:     true,


### PR DESCRIPTION
Adds a new "-download" flag which will instruct browsers to download the files. Useful for static download servers.